### PR TITLE
gameoverコマンド受信時に探索を停止するように修正

### DIFF
--- a/src/usi.rs
+++ b/src/usi.rs
@@ -520,7 +520,7 @@ pub fn cmd_loop() {
                     .store(false, std::sync::atomic::Ordering::Relaxed);
             }
             "position" => position(&mut pos, &args[1..]),
-            "quit" | "stop" => {
+            "quit" | "stop" | "gameover" => {
                 thread_pool
                     .stop
                     .store(true, std::sync::atomic::Ordering::Relaxed);


### PR DESCRIPTION
gameoverコマンド受信時に探索を停止するように修正しました。
ponder探索時に対局相手が投了した場合に、対局終了後も探索し続け、連続対局できなかったため。