### PR TITLE
ビルド設定の変更

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,4 +1,5 @@
 [build]
 rustflags = [
+    "--emit", "asm,llvm-bc,llvm-ir", "-C", "llvm-args=--x86-asm-syntax=intel",
     "-C", "target-cpu=native",
 ]

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,4 @@
+[build]
+rustflags = [
+    "-C", "target-cpu=native",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ rayon = "*"
 regex = "*"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+
+[profile.release]
+lto = true

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+stable


### PR DESCRIPTION
https://github.com/HiraokaTakuya/apery_rust/issues/1

- toolchain を nightly から stable に変更
- lto を 有効化
- target-cpu を native に設定
- アセンブラ、LLVM IR 等をビルド時に併せて出力

不要な変更は適宜Commitを除去なりRevertなりお願いします。